### PR TITLE
Implementation of add and remove organization

### DIFF
--- a/certs_wallet/src/access_control_list.rs
+++ b/certs_wallet/src/access_control_list.rs
@@ -1,0 +1,59 @@
+//! Module AccessControlList
+//!
+//! Module responsible of managing the ACL that allows organizations to deposit `Chaincerts` to a wallet
+use soroban_sdk::{vec, Bytes, Env, Vec};
+
+use super::storage_types::DataKey;
+
+const ACL_KEY: DataKey = DataKey::Acl;
+
+pub(crate) fn add_organization(env: &Env, org_id: &Bytes) {
+    let acl = match env.storage().get(&ACL_KEY) {
+        Some(acl) => {
+            let mut access_list: Vec<Bytes> = acl.unwrap();
+            if !is_organization_in_acl(org_id, &access_list) {
+                access_list.push_front(org_id.clone());
+                access_list
+            } else {
+                panic!("The organization is already on the ACL")
+            }
+        }
+        None => {
+            let access_list: Vec<Bytes> = vec![env, org_id.clone()];
+            access_list
+        }
+    };
+    env.storage().set(&ACL_KEY, &acl)
+}
+
+pub(crate) fn remove_organization(env: &Env, org_id: &Bytes) {
+    match env.storage().get(&ACL_KEY) {
+        Some(acl) => {
+            let mut access_list: Vec<Bytes> = acl.unwrap();
+            remove_from_acl(org_id, &mut access_list);
+            env.storage().set(&ACL_KEY, &access_list)
+        }
+        None => {
+            panic!("There are no organizations in the ACL")
+        }
+    }
+}
+
+fn remove_from_acl(org_id: &Bytes, access_list: &mut Vec<Bytes>) {
+    for (index, org) in access_list.iter().enumerate() {
+        if org.unwrap() == org_id.clone() {
+            access_list.remove(index as u32).unwrap();
+            return;
+        }
+    }
+    panic!("The organization doesn't exist in the ACL")
+}
+
+fn is_organization_in_acl(org_id: &Bytes, access_list: &Vec<Bytes>) -> bool {
+    for org in access_list.iter() {
+        if org.unwrap() == org_id.clone() {
+            return true;
+        }
+    }
+    false
+}

--- a/certs_wallet/src/lib.rs
+++ b/certs_wallet/src/lib.rs
@@ -1,9 +1,10 @@
 #![no_std]
+mod access_control_list;
 mod chaincert;
 mod option;
 mod owner;
 mod storage_types;
-use soroban_sdk::{contractimpl, Address, Env};
+use soroban_sdk::{contractimpl, Address, Bytes, Env};
 
 pub struct Wallet;
 
@@ -14,6 +15,18 @@ impl Wallet {
             panic!("This wallet is already initialized");
         }
         owner::write_owner(&env, &owner);
+    }
+
+    /// Add organizations to the ACL
+    pub fn add_org(env: Env, org_id: Bytes) {
+        owner::read_owner(&env).require_auth();
+        access_control_list::add_organization(&env, &org_id)
+    }
+
+    /// Remove organizations from the ACL
+    pub fn rmv_org(env: Env, org_id: Bytes) {
+        owner::read_owner(&env).require_auth();
+        access_control_list::remove_organization(&env, &org_id)
     }
 }
 

--- a/certs_wallet/src/owner.rs
+++ b/certs_wallet/src/owner.rs
@@ -11,6 +11,10 @@ pub(crate) fn has_owner(env: &Env) -> bool {
     env.storage().has(&OWNER_KEY)
 }
 
+pub(crate) fn read_owner(env: &Env) -> Address {
+    env.storage().get_unchecked(&OWNER_KEY).unwrap()
+}
+
 pub(crate) fn write_owner(env: &Env, owner: &Address) {
     env.storage().set(&OWNER_KEY, owner);
 }

--- a/certs_wallet/src/storage_types.rs
+++ b/certs_wallet/src/storage_types.rs
@@ -7,4 +7,6 @@ use soroban_sdk::contracttype;
 #[contracttype]
 pub enum DataKey {
     Owner,
+    /// Access Control List
+    Acl,
 }

--- a/certs_wallet/src/test.rs
+++ b/certs_wallet/src/test.rs
@@ -1,7 +1,7 @@
 #![cfg(test)]
 
 use crate::{Wallet, WalletClient};
-use soroban_sdk::{testutils::Address as _, Address, Env};
+use soroban_sdk::{testutils::Address as _, vec, Address, Bytes, Env, IntoVal, Vec};
 
 fn create_wallet(e: &Env, owner: &Address) -> WalletClient {
     let wallet = WalletClient::new(e, &e.register_contract(None, Wallet {}));
@@ -9,18 +9,73 @@ fn create_wallet(e: &Env, owner: &Address) -> WalletClient {
     wallet
 }
 
+struct ChaincertWalletTest {
+    owner: Address,
+    wallet: WalletClient,
+    organizations: Vec<Bytes>,
+}
+
+impl ChaincertWalletTest {
+    fn setup() -> Self {
+        let env: Env = Default::default();
+        let owner = Address::random(&env);
+        let wallet = create_wallet(&env, &owner);
+        let org_id1: Bytes = "ORG1".into_val(&env);
+        let org_id2: Bytes = "ORG2".into_val(&env);
+        let organizations = vec![&env, org_id1, org_id2];
+
+        ChaincertWalletTest {
+            owner,
+            wallet,
+            organizations,
+        }
+    }
+}
+
 #[test]
 fn test_successful_execution_of_wallet_capabilities() {
-    let env: Env = Default::default();
-    let owner = Address::random(&env);
-    create_wallet(&env, &owner);
+    let test = ChaincertWalletTest::setup();
+
+    test.wallet
+        .add_org(&test.organizations.get_unchecked(0).unwrap());
+    test.wallet
+        .add_org(&test.organizations.get_unchecked(1).unwrap());
+    test.wallet
+        .rmv_org(&test.organizations.get_unchecked(0).unwrap());
 }
 
 #[test]
 #[should_panic(expected = "This wallet is already initialized")]
 fn test_initialize_an_already_initialized_wallet() {
-    let env: Env = Default::default();
-    let owner = Address::random(&env);
-    let wallet = create_wallet(&env, &owner);
-    wallet.initialize(&owner);
+    let test = ChaincertWalletTest::setup();
+    test.wallet.initialize(&test.owner);
+}
+
+#[test]
+#[should_panic(expected = "The organization is already on the ACL")]
+fn test_when_adding_an_already_added_org() {
+    let test = ChaincertWalletTest::setup();
+
+    test.wallet
+        .add_org(&test.organizations.get_unchecked(0).unwrap());
+    test.wallet
+        .add_org(&test.organizations.get_unchecked(0).unwrap());
+}
+
+#[test]
+#[should_panic(expected = "There are no organizations in the ACL")]
+fn test_remove_organization_when_not_organizations_already_set() {
+    let test = ChaincertWalletTest::setup();
+    test.wallet
+        .rmv_org(&test.organizations.get_unchecked(0).unwrap());
+}
+
+#[test]
+#[should_panic(expected = "The organization doesn't exist in the ACL")]
+fn test_remove_organization_when_organization_not_found() {
+    let test = ChaincertWalletTest::setup();
+    test.wallet
+        .add_org(&test.organizations.get_unchecked(0).unwrap());
+    test.wallet
+        .rmv_org(&test.organizations.get_unchecked(1).unwrap());
 }


### PR DESCRIPTION
## Description

This PR includes the `add_organization` and `remove_organization` functions in the Certs Wallet contract. These functions enable the wallet owner to manage the list of organizations that are allowed to distribute Chaincerts to the wallet. With these new functions, the wallet owner can easily add or remove organizations from the list as needed.

Closes #11 


## Type of change

- [x] New feature (non-breaking change which adds functionality)


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my change